### PR TITLE
Fix GoMultifunctionalityMetrics class adding obo path

### DIFF
--- a/protein_metamorphisms_is/config/config.yaml
+++ b/protein_metamorphisms_is/config/config.yaml
@@ -100,11 +100,19 @@ constants: "config/constants.yaml"
 fasta_path: "~/data/complete.fasta"
 cdhit_out_path: "~/data/cd_hitout"
 
-# Identity threshold for clustering
+## Sequence Clustering
+# Identity threshold for sequence clustering
 sequence_identity_threshold: 0.98
 
-# Minimum alignment coverage for clustering
+# Minimum alignment coverage for sequence clustering
 alignment_coverage: 0.95
+
+## Structural Subclustering
+# Identity threshold for structural subclustering
+structural_identity_threshold: 0.65
+
+# Minimum alignment coverage for structural subclustering
+structural_alignment_coverage: 0.95
 
 #Maximum memory usage for CD-HIT
 memory_usage: 25000

--- a/protein_metamorphisms_is/operation/clustering/structural_subclustering.py
+++ b/protein_metamorphisms_is/operation/clustering/structural_subclustering.py
@@ -92,10 +92,10 @@ class StructuralSubClustering(BaseTaskInitializer):
         cd_hit(
             i=fasta_path,
             o=cdhit_out_path,
-            c=0.65,
+            c=self.conf.get('structural_identity_threshold', 0.65),
             d=0,
             sc=1,
-            aL=self.conf.get('alignment_coverage', 0.9),
+            aL=self.conf.get('structural_alignment_coverage', 0.9),
             M=self.conf.get('memory_usage', 1024),
             T=self.conf.get('max_workers', 4),
             g=self.conf.get('most_representative_search', 1)

--- a/protein_metamorphisms_is/operation/functional/multifunctionality/go_multifunctionality_metrics.py
+++ b/protein_metamorphisms_is/operation/functional/multifunctionality/go_multifunctionality_metrics.py
@@ -22,7 +22,8 @@ class GoMultifunctionalityMetrics(QueueTaskInitializer):
             conf (dict): Configuration dictionary containing paths to OBO and GAF files.
         """
         super().__init__(conf)
-        self.go = get_godag('../data/go-basic.obo', optional_attrs='relationship')
+        self.obo_path = self.conf.get('obo', '../data/go-basic.obo')
+        self.go = get_godag(self.obo_path, optional_attrs='relationship')
         self.logger.info("GoMetrics instance created")
         self.reference_attribute = "go_terms_per_protein"
 

--- a/protein_metamorphisms_is/operation/functional/multifunctionality/go_multifunctionality_metrics.py
+++ b/protein_metamorphisms_is/operation/functional/multifunctionality/go_multifunctionality_metrics.py
@@ -22,7 +22,7 @@ class GoMultifunctionalityMetrics(QueueTaskInitializer):
             conf (dict): Configuration dictionary containing paths to OBO and GAF files.
         """
         super().__init__(conf)
-        self.go = get_godag('go-basic.obo', optional_attrs='relationship')
+        self.go = get_godag('../data/go-basic.obo', optional_attrs='relationship')
         self.logger.info("GoMetrics instance created")
         self.reference_attribute = "go_terms_per_protein"
 


### PR DESCRIPTION
Es lo que añadimos ayer al ejecutarlo en mi portátil que no detectaba el fichero
IMP: también es la tarea que me encargaste de añadir parámetros de configuración para el subclustering, que he puesto los dos en el mismo pull sin querer xd